### PR TITLE
Disable IpReachability monitor

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -167,6 +167,9 @@
     <integer name="config_safe_media_volume_index">10</integer>
 
     <bool name="config_enableWifiDisplay">true</bool>
+    
+    <!-- Disable IpReachability monitor -->
+    <bool name="config_wifi_ipreachability_monitor">false</bool>
 
     <!-- Minimum span needed to begin a touch scaling gesture.
          If the span is equal to or greater than this size, a scaling gesture


### PR DESCRIPTION
For fixing wifi drop when asleep. Full list of changes needed: https://review.cyanogenmod.org/#/q/topic:IpReachabilityMon+status:merged
